### PR TITLE
Fixes Jenkins failure on build 324

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ catkin_package(
 link_directories(${GAZEBO_LIBRARY_DIRS})
 include_directories(
   include
+  ${TBB_INCLUDE_DIR}
   ${Boost_INCLUDE_DIR}
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}


### PR DESCRIPTION
The error reported here https://bbpcode.epfl.ch/ci/view/neurorobotics/job/neurorobotics.GazeboRosPackages.cscs.gerrit/324/console is:
‘enqueue’ is not a member of ‘tbb::task’
                 tbb::task::enqueue(*task);
                 ^

This happens because CMake doesn't read the headers of tbb.