### PR TITLE
Rework implementation to be independent of camera sensor update rate.

### DIFF
--- a/include/gazebo_dvs_plugin/dvs_plugin.hpp
+++ b/include/gazebo_dvs_plugin/dvs_plugin.hpp
@@ -82,7 +82,7 @@ namespace gazebo
     private: bool has_last_image;
     private: float event_threshold;
     private: void processDelta(Mat *last_image, Mat *curr_image);
-    private: void fillEvents(Mat diff, int polarity, vector<dvs_msgs::Event> *events);
+    private: void fillEvents(Mat *diff, int polarity, vector<dvs_msgs::Event> *events);
     private: void publishEvents(vector<dvs_msgs::Event> *events);
   };
 }


### PR DESCRIPTION
Instead of differentiating consecutive images, we differentiate the current image with a "state" image, which is locally updated on event emission